### PR TITLE
NetworkTables compatability

### DIFF
--- a/src/Robot.cpp
+++ b/src/Robot.cpp
@@ -39,8 +39,8 @@ Robot::Robot()
         , m_teleop(new Teleop(m_driverJoystick, m_operatorJoystick,
                               m_tuningJoystick))
         , m_test(new Test(m_driverJoystick, m_operatorJoystick,
-                          m_tuningJoystick, m_elevator)) {
-        , m_dashboard(NetworkTableInstance::GetDefault())
+                          m_tuningJoystick, m_elevator))
+        , m_dashboard(NetworkTableInstance::GetDefault()) {
     std::cout << "Constructed a Robot!" << std::endl;
 }
 

--- a/src/Robot.h
+++ b/src/Robot.h
@@ -78,7 +78,7 @@ private:
     TalonSRX *m_clawRightRoller;
     DigitalInput *m_clawCubeSensor;
     TalonSRX *m_elevatorMotor;
-    
+
     Elevator *m_elevator;
     Claw *m_claw;
     Drive *m_drive;


### PR DESCRIPTION
Will work with components on the bot. Transmits bot info over network tables.