### PR TITLE
Fixed the fallback SSH user to target_user and removed leading zero from ip

### DIFF
--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -33,9 +33,9 @@ deploy
 TEAM_NUMBER=$(printf "%04d" "$TEAM_NUMBER")
 P1=${TEAM_NUMBER:0:2}
 P2=${TEAM_NUMBER:2:2}
-TARGET="10.$P1.$P2.2"
+TARGET="10.$((10#$P1)).$P2.2"
 echo "Not found - probing for $TARGET..."
-ssh "$USER@$TARGET" true > /dev/null 2>&1
+ssh "$TARGET_USER@$TARGET" true > /dev/null 2>&1
 deploy
 
 echo "Not found - giving up."


### PR DESCRIPTION
The 'TE' of 10.TE.AM.2 is now stripping the leading zero by converting itself into base 10.

The ssh command was also setup with '$USER' instead of '$TARGET_USER', which meant that deploy would fail even if the ip was found.

Tested and working