### PR TITLE
GreyTalonSRX inherits virtually from TalonSRX and from BaseMotorcontr…

### DIFF
--- a/lib/helpers/GreyTalon.h
+++ b/lib/helpers/GreyTalon.h
@@ -2,37 +2,55 @@
 #include "Phoenix.h"
 
 namespace frc973 {
-TalonSRX* FactoryReset(TalonSRX* motor) {
-    motor->ConfigSelectedFeedbackSensor(
-        FeedbackDevice::QuadEncoder, 0,
-        10);  // 0 = Not cascaded PID Loop; 10 = in constructor, not in a loop
-    motor->SetSensorPhase(false);
-    motor->SetInverted(false);
-    motor->SetNeutralMode(NeutralMode::Coast);
 
-    motor->ConfigNominalOutputForward(0.0, 10);
-    motor->ConfigNominalOutputReverse(0.0, 10);
-    motor->ConfigPeakOutputForward(1.0, 10);
-    motor->ConfigPeakOutputReverse(-1.0, 10);
+class GreyTalonSRX :
+    public virtual BaseMotorController,
+    public virtual TalonSRX {
 
-    // Gains
-    motor->Config_kP(0, 0.0, 10);
-    motor->Config_kI(0, 0.0, 10);
-    motor->Config_kD(0, 0.0, 10);
-    motor->Config_kF(0, 0.0, 10);
-    motor->ConfigMotionCruiseVelocity(0.0, 10);
-    motor->ConfigMotionAcceleration(0.0, 10);
+public:
+    GreyTalonSRX(int canId)
+        : BaseMotorController(canId | 0x02040000)
+        , TalonSRX(canId)
+    {
+        FactoryReset(this);
+    }
 
-    // Limiting
-    motor->EnableCurrentLimit(false);
-    motor->ConfigPeakCurrentDuration(0, 10);
-    motor->ConfigPeakCurrentLimit(0, 10);
-    motor->ConfigContinuousCurrentLimit(0, 10);
-    motor->EnableVoltageCompensation(false);
-    motor->ConfigVoltageCompSaturation(12, 10);
+    virtual ~GreyTalonSRX() {}
 
-    motor->Set(ControlMode::PercentOutput, 0.0);
+    TalonSRX* FactoryReset(TalonSRX* motor) {
+        motor->ConfigSelectedFeedbackSensor(
+            FeedbackDevice::QuadEncoder, 0,
+            10);  // 0 = Not cascaded PID Loop; 10 = in constructor, not in a loop
+        motor->SetSensorPhase(false);
+        motor->SetInverted(false);
+        motor->SetNeutralMode(NeutralMode::Coast);
 
-    return motor;
-}
+        motor->ConfigNominalOutputForward(0.0, 10);
+        motor->ConfigNominalOutputReverse(0.0, 10);
+        motor->ConfigPeakOutputForward(1.0, 10);
+        motor->ConfigPeakOutputReverse(-1.0, 10);
+
+        // Gains
+        motor->Config_kP(0, 0.0, 10);
+        motor->Config_kI(0, 0.0, 10);
+        motor->Config_kD(0, 0.0, 10);
+        motor->Config_kF(0, 0.0, 10);
+        motor->ConfigMotionCruiseVelocity(0.0, 10);
+        motor->ConfigMotionAcceleration(0.0, 10);
+
+        // Limiting
+        motor->EnableCurrentLimit(false);
+        motor->ConfigPeakCurrentDuration(0, 10);
+        motor->ConfigPeakCurrentLimit(0, 10);
+        motor->ConfigContinuousCurrentLimit(0, 10);
+        motor->EnableVoltageCompensation(false);
+        motor->ConfigVoltageCompSaturation(12, 10);
+
+        motor->Set(ControlMode::PercentOutput, 0.0);
+
+        return motor;
+    }
+
+};
+
 }

--- a/src/Robot.cpp
+++ b/src/Robot.cpp
@@ -24,11 +24,10 @@ Robot::Robot()
         , m_tuningJoystick(
               new ObservableJoystick(TUNING_JOYSTICK_PORT, this, this))
         , m_logger(new LogSpreadsheet(this))
-        , m_clawLeftRoller(FactoryReset(new TalonSRX(CLAW_LEFT_ROLLER_CAN_ID)))
-        , m_clawRightRoller(
-              FactoryReset(new TalonSRX(CLAW_RIGHT_ROLLER_CAN_ID)))
+        , m_clawLeftRoller(new GreyTalonSRX(CLAW_LEFT_ROLLER_CAN_ID))
+        , m_clawRightRoller(new GreyTalonSRX(CLAW_RIGHT_ROLLER_CAN_ID))
         , m_clawCubeSensor(new DigitalInput(CUBE_BANNER_SENSOR_DIN))
-        , m_elevatorMotor(FactoryReset(new TalonSRX(ELEVATOR_CAN_ID)))
+        , m_elevatorMotor(new GreyTalonSRX(ELEVATOR_CAN_ID))
         , m_elevator(
               new Elevator(this, m_logger, m_driverJoystick, m_elevatorMotor))
         , m_claw(new Claw(this, m_logger, m_clawLeftRoller, m_clawRightRoller,


### PR DESCRIPTION
TalonSRX has two virtual parents: BaseMotorController and IMotorControllerEnhanced.  BaseMotorController and IMotorControllerEnhanved both inherit from MotorController.  

If gcc had let us do our regular naieve inheritance, the TalonSRX constructor would try to instantiate two MotorController classes.  This is bad news bears because when we try to access TalonSRX::SetInverted, it would be unclear which MotorController instance to call into (remember there would hypothetically be two MotorController instances in one TalonSRX).

gcc lets us get around this issue by doing "virtual inheritance" which means that there's an indirect pointer somewhere in the TalonSRX object that points to the parent instance.  As a side-effect, we hvae to explicitly inherit from and instantiate BaseMotorController.  

https://www.cprogramming.com/tutorial/virtual_inheritance.html

C++ is the worst language.  