### PR TITLE
Enum rule addition to Style guide

### DIFF
--- a/docs/StyleGuide.md
+++ b/docs/StyleGuide.md
@@ -50,7 +50,7 @@ private:
 ```
 
 ### Rule #2: Naming variables according to scope
-Member, static, and global variables should be named starting with `m_`, `s_`, or `g_` respectively. In declaring member variables in a class, there should be a space between the type and the name.
+Member, static, and global variables should be named starting with `m_`, `s_`, or `g_` respectively. In declaring member variables in a class, there should be a space between the type and the name. Declaring constants should have all characters in uppercase and should use underscores instead of spaces.
 ```c++
 int g_value = 10
 class MyClass() {


### PR DESCRIPTION
Here's the new PR on the enum class amendment to the style guide. Apparently, my elevator changes were still in my local repo even though I switched to dev and pulled from it. Sorry for the confusion.