### PR TITLE
Added tool to throw sample data into networktables to test GreyDash

### DIFF
--- a/GreyDash/src/ui.js
+++ b/GreyDash/src/ui.js
@@ -70,6 +70,7 @@ for (let i = 0; i < config.charts.length; i += 1) {
     tooltip: config.charts[i].settings.tooltip,
     minValue: config.charts[i].settings.minValue,
     maxValue: config.charts[i].settings.maxValue,
+    interpolation: 'step',
   });
   config.charts[i].chart.streamTo(config.charts[i].displayChart, 0);
 

--- a/tools/dashtool/BUILD
+++ b/tools/dashtool/BUILD
@@ -1,0 +1,5 @@
+
+py_binary(
+    name = "sim-bot",
+    srcs = ["sim-bot.py"],
+)

--- a/tools/dashtool/sim-bot.py
+++ b/tools/dashtool/sim-bot.py
@@ -1,0 +1,15 @@
+"""
+Spew random-ish data to network tables so we can (partially) test GreyDash
+without robot access
+"""
+import time
+from networktables import NetworkTables
+import random
+
+NetworkTables.initialize()
+
+sd = NetworkTables.getTable("SmartDashboard")
+
+while True:
+    sd.putNumber("misc/pdp/batteryvoltage", 12 + random.random())
+    time.sleep(0.5)


### PR DESCRIPTION
I used this python script to test how well the GreyDash reconnects to the robot.  Looks like GreyDash does pretty well; good job on the update :+1:  

Feel free to throw this PR away.  It's a pretty crude test and it's not a substitute for real testing on the robot.  

For some reason this test doesn't run on the style-dash branch.  Does the style-dash branch work on the robot?  Has style-dash been tested recently?  It style-dash does work on the robot then this is a pretty bad test.  